### PR TITLE
Homepage content, search and layout

### DIFF
--- a/public/js/p3/resources/bv-brc.css
+++ b/public/js/p3/resources/bv-brc.css
@@ -45,7 +45,6 @@
 }
 #bv-brc-header-container {
   display: flex;
-  justify-content: space-between;
   /* max-width: 1220px; */
   margin: 0 auto;
 }
@@ -144,6 +143,44 @@
   background-color: var(--blue-light-bg);
   border-bottom: 4px solid var(--border-blue);
   padding: 15px 10px;
+}
+
+#bv-brc-home .bv-brc-info h3 {
+  margin: 0.5em 0em;
+}
+
+#bv-brc-home .bv-brc-info .browse {
+  margin-top: 20px;
+}
+
+#bv-brc-home .bv-brc-info .search .global-search {
+  margin-left: 16px;
+}
+
+#bv-brc-home .bv-brc-info .search .global-search .GSbody {
+  border: 2px solid var(--blue);
+  border-bottom: 4px solid var(--blue);
+}
+
+#bv-brc-home .bv-brc-info .search .global-search .gs-data-types-dropdown .dijitInputField {
+  font-size: 14px;
+  padding: 12px 4px;
+}
+
+#bv-brc-home .bv-brc-info .search .global-search .gs-input .dijitInputField {
+  font-family: inherit;
+  font-size: 14px;
+  padding: 12px 8px;
+}
+
+#bv-brc-home .bv-brc-info .search .global-search .gs-input .dijitPlaceHolder {
+  font-size: 14px;
+  padding: 12px 8px;
+}
+
+#bv-brc-home .bv-brc-info .search .global-search .gs-options-dropdown .dijitInputField {
+  font-size: 14px;
+  padding: 12px 4px;
 }
 
 #bv-brc-home .patric-info {
@@ -493,7 +530,7 @@
   padding-bottom: 20px;
 }
 
-/* Grid Tablet Layout */
+/* Tablet */
 @media (max-width: 991px) {
   #bv-brc-home #bv-brc-home-container {
     display: -webkit-box;
@@ -508,7 +545,7 @@
   #bv-brc-home .grid-container {
     display: grid;
     grid-template-columns: 365px 365px;
-    grid-template-rows: 40px 175px 660px 425px;
+    grid-template-rows: 40px 260px 480px 425px;
     grid-gap: 20px;
   }
   #bv-brc-home .home-banner {
@@ -535,11 +572,21 @@
     grid-column: 2 / 3;
     grid-row: 4 / 5;
   }
+  #bv-brc-home .btn {
+    padding: 0.4rem 1rem;
+    font-size: .8rem!important;
+  }
+  #bv-brc-home .patric-info-content .hp-img  {
+    display: none;
+  }
   #bv-brc-home .patric-info .patric-info-btn-links {
-    margin-top: 28px;
+    margin-top: -23px;
+  }
+  #bv-brc-home .ird-vipr-info-content .hp-img  {
+    display: none;
   }
   #bv-brc-home .ird-vipr-info .ird-vipr-info-btn-links {
-    margin-top: -4px;
+    margin-top: -10px;
   }
 }
 /* Grid Desktop Layout */
@@ -557,7 +604,7 @@
   #bv-brc-home .grid-container {
     display: grid;
     grid-template-columns: 440px 440px 300px;
-    grid-template-rows: 40px 150px 240px 150px 150px;
+    grid-template-rows: 40px 260px 140px 150px 250px;
     grid-gap: 20px;
   }
   #bv-brc-home .home-banner {

--- a/views/bv-brc-header.ejs
+++ b/views/bv-brc-header.ejs
@@ -66,128 +66,130 @@
                 </a>
             </div>
 
-            <div class="topMenuButton showOnLoad dijitHidden" data-dojo-type="dijit/form/DropDownButton">
-                <span>ORGANISMS</span>
-                <div data-dojo-type="p3/widget/TooltipDialog">
-                    <div style="vertical-align: top;width:225px;display:inline-block;margin-right: 5px;">
-                        <div class="menuHeader">Bacterial Pathogens</div>
-                        <div class="menuItems">
-                            <% for (var i = 0; i < servicesMiddle;i++){ %>
-                            <div>
-                                <span class="menuItem half">
-                                    <a class="navigationLink" href="<%- services[i].href %>" title="<%- services[i].name %> overview"><%- services[i].name %></a>
-                                </span>
-                                <span class="menuItem half">
-                                    <% if (services[servicesMiddle + i]) { %>
-                                    <a class="navigationLink" title="<%- services[servicesMiddle + i].name %> overview"
-                                       href="<%- services[servicesMiddle + i].href %>"><%- services[servicesMiddle + i].name %></a>
-                                    <% } %>
-                                </span>
-                            </div>
-                            <% } %>
-                            <br>
-                            <div>
-                                <span class="menuItem half">
-                                    <a class="navigationLink" href="/view/Taxonomy/2" title="Overview page for all Bacteria genomes">All Bacteria</a>
-                                </span>
-                                <span class="menuItem half">
-                                    <a class="navigationLink" href="/view/Taxonomy/2157" title="Overview page for all Archea genomes">All Archaea</a>
-                                </span>
-                                <span class="menuItem half">
-                                    <a class="navigationLink" href="/view/Taxonomy/10239" title="Overview page for all Phage genomes">All Phages</a>
-                                </span>
-                                <span class="menuItem half">
-                                    <a class="navigationLink" href="/view/Host/?eq(taxon_lineage_ids,2759)#view_tab=genomes"
-                                        title="Overview page for all Eukaryotic host genomes">Eukaryotic Hosts</a></span>
-                            </div>
-                        </div>
-                    </div>
-
-                    <div style="vertical-align: top;width:300px;display:inline-block;margin-right: 5px;">
-                        <div class="menuHeader">Viral Families</div>
-
-                        <div class="menuItems">
-                            <% for (var i = 0; i < virusMiddle;i++){ %>
-                            <div>
-                                <span class="menuItem half">
-                                    <a class="navigationLink" href="<%- virus[i].href %>" title="<%- virus[i].name %> overview"><%- virus[i].name %></a>
-                                </span>
-                                <span class="menuItem half">
-                                    <% if (virus[virusMiddle + i]) { %>
-                                    <a class="navigationLink" title="<%- virus[virusMiddle + i].name %> overview"
-                                       href="<%- virus[virusMiddle + i].href %>"><%- virus[virusMiddle + i].name %></a>
-                                    <% } %>
-                                </span>
-                            </div>
-                            <% } %>
-                        </div>
-
-                    </div>
-                </div>
-            </div>
-
-            <div class="topMenuButton showOnLoad dijitHidden" data-dojo-type="dijit/form/DropDownButton">
-                <span>DATA</span>
-                <div data-dojo-type="p3/widget/TooltipDialog">
-                    <div>
-                        <div style="vertical-align: top;width:150px;display:inline-block;margin-right: 5px;">
-                            <div class="menuHeader">Data Types</div>
+            <div style="vertical-align: top; min-width: 435px; flex: 1">
+                <div class="topMenuButton showOnLoad dijitHidden" data-dojo-type="dijit/form/DropDownButton">
+                    <span>ORGANISMS</span>
+                    <div data-dojo-type="p3/widget/TooltipDialog">
+                        <div style="vertical-align: top;width:225px;display:inline-block;margin-right: 5px;">
+                            <div class="menuHeader">Bacterial Pathogens</div>
                             <div class="menuItems">
-                                <div><a class="navigationLinkOut" href="<%- request.applicationOptions.docsServiceURL %>user_guides/data/data_types/antimicrobial_resistance.html">Antimicrobial Resistance (AMR)</a></div>
-                                <div><a class="navigationLinkOut" href="<%- request.applicationOptions.docsServiceURL %>user_guides/data/data_types/genomes.html">Genomes</a></div>
-                                <div><a class="navigationLinkOut" href="<%- request.applicationOptions.docsServiceURL %>user_guides/data/data_types/genomic_features.html">Genomic Features</a></div>
-                                <div><a class="navigationLinkOut" href="<%- request.applicationOptions.docsServiceURL %>user_guides/data/data_types/pathways.html">Pathways</a></div>
-                                <div><a class="navigationLinkOut" href="<%- request.applicationOptions.docsServiceURL %>user_guides/data/data_types/protein_families.html">Protein Families</a></div>
-                                <div><a class="navigationLinkOut" href="<%- request.applicationOptions.docsServiceURL %>user_guides/data/data_types/specialty_genes.html">Specialty Genes</a></div>
-                                <div><a class="navigationLinkOut" href="<%- request.applicationOptions.docsServiceURL %>user_guides/data/data_types/transcriptomics.html">Transcriptomics</a></div>
-                            </div>
-                            <div class="menuHeader">Download Data</div>
-                            <div class="menuItems">
-                                <div><a class="navigationLinkOut" href="ftp://ftp.patricbrc.org/"
-                                        target="_blank" rel="noopener">FTP Server</a>
+                                <% for (var i = 0; i < servicesMiddle;i++){ %>
+                                <div>
+                                    <span class="menuItem half">
+                                        <a class="navigationLink" href="<%- services[i].href %>" title="<%- services[i].name %> overview"><%- services[i].name %></a>
+                                    </span>
+                                    <span class="menuItem half">
+                                        <% if (services[servicesMiddle + i]) { %>
+                                        <a class="navigationLink" title="<%- services[servicesMiddle + i].name %> overview"
+                                           href="<%- services[servicesMiddle + i].href %>"><%- services[servicesMiddle + i].name %></a>
+                                        <% } %>
+                                    </span>
+                                </div>
+                                <% } %>
+                                <br>
+                                <div>
+                                    <span class="menuItem half">
+                                        <a class="navigationLink" href="/view/Taxonomy/2" title="Overview page for all Bacteria genomes">All Bacteria</a>
+                                    </span>
+                                    <span class="menuItem half">
+                                        <a class="navigationLink" href="/view/Taxonomy/2157" title="Overview page for all Archea genomes">All Archaea</a>
+                                    </span>
+                                    <span class="menuItem half">
+                                        <a class="navigationLink" href="/view/Taxonomy/10239" title="Overview page for all Phage genomes">All Phages</a>
+                                    </span>
+                                    <span class="menuItem half">
+                                        <a class="navigationLink" href="/view/Host/?eq(taxon_lineage_ids,2759)#view_tab=genomes"
+                                            title="Overview page for all Eukaryotic host genomes">Eukaryotic Hosts</a></span>
                                 </div>
                             </div>
                         </div>
-                        <div style="vertical-align:top;width:200px;display: inline-block">
-                            <div class="menuHeader">Specialty Data Collections</div>
+
+                        <div style="vertical-align: top;width:300px;display:inline-block;margin-right: 5px;">
+                            <div class="menuHeader">Viral Families</div>
+
                             <div class="menuItems">
-                                <div><a class="navigationLinkOut" href="<%- request.applicationOptions.docsServiceURL %>user_guides/data/specialty_data_collections/patric_collaborations.html">PATRIC Collaborations</a></div>
-                                <div><a class="navigationLinkOut" href="<%- request.applicationOptions.docsServiceURL %>user_guides/data/specialty_data_collections/patric_dbps.html">PATRIC DBPS</a></div>
-                                <div><a class="navigationLinkOut" href="<%- request.applicationOptions.docsServiceURL %>user_guides/data/specialty_data_collections/niaid_clinical_proteomics.html">NIAID Clinical Proteomics</a></div>
-                                <div><a class="navigationLinkOut" href="<%- request.applicationOptions.docsServiceURL %>user_guides/data/specialty_data_collections/niaid_genome_sequencing.html">NIAID Genome Sequencing</a></div>
-                                <div><a class="navigationLinkOut" href="<%- request.applicationOptions.docsServiceURL %>user_guides/data/specialty_data_collections/niaid_structural_genomics.html">NIAID Structural Genomics</a></div>
-                                <div><a class="navigationLinkOut" href="<%- request.applicationOptions.docsServiceURL %>user_guides/data/specialty_data_collections/niaid_systems_biology.html">NIAID Systems Biology</a></div>
-                                <div><a class="navigationLinkOut" href="<%- request.applicationOptions.docsServiceURL %>user_guides/data/specialty_data_collections/niaid_functional_genomics.html">NIAID Functional Genomics</a></div>
+                                <% for (var i = 0; i < virusMiddle;i++){ %>
+                                <div>
+                                    <span class="menuItem half">
+                                        <a class="navigationLink" href="<%- virus[i].href %>" title="<%- virus[i].name %> overview"><%- virus[i].name %></a>
+                                    </span>
+                                    <span class="menuItem half">
+                                        <% if (virus[virusMiddle + i]) { %>
+                                        <a class="navigationLink" title="<%- virus[virusMiddle + i].name %> overview"
+                                           href="<%- virus[virusMiddle + i].href %>"><%- virus[virusMiddle + i].name %></a>
+                                        <% } %>
+                                    </span>
+                                </div>
+                                <% } %>
                             </div>
 
                         </div>
                     </div>
                 </div>
-            </div>
 
-            <div class="topMenuButton showOnLoad dijitHidden" data-dojo-type="dijit/form/DropDownButton">
-                <span style="font-size: 1em; line-height: 1.5; margin-top: -10px;">WORKSPACES</span>
-
-                <div data-dojo-type="p3/widget/TooltipDialog">
-                    <div>
-                        <div style="vertical-align: top;width:175px;display:inline-block">
-                            <div class="HideWithAuth">
-                                Please <a class="loginLink">sign in</a> to view your workspaces.
+                <div class="topMenuButton showOnLoad dijitHidden" data-dojo-type="dijit/form/DropDownButton">
+                    <span>DATA</span>
+                    <div data-dojo-type="p3/widget/TooltipDialog">
+                        <div>
+                            <div style="vertical-align: top;width:150px;display:inline-block;margin-right: 5px;">
+                                <div class="menuHeader">Data Types</div>
+                                <div class="menuItems">
+                                    <div><a class="navigationLinkOut" href="<%- request.applicationOptions.docsServiceURL %>user_guides/data/data_types/antimicrobial_resistance.html">Antimicrobial Resistance (AMR)</a></div>
+                                    <div><a class="navigationLinkOut" href="<%- request.applicationOptions.docsServiceURL %>user_guides/data/data_types/genomes.html">Genomes</a></div>
+                                    <div><a class="navigationLinkOut" href="<%- request.applicationOptions.docsServiceURL %>user_guides/data/data_types/genomic_features.html">Genomic Features</a></div>
+                                    <div><a class="navigationLinkOut" href="<%- request.applicationOptions.docsServiceURL %>user_guides/data/data_types/pathways.html">Pathways</a></div>
+                                    <div><a class="navigationLinkOut" href="<%- request.applicationOptions.docsServiceURL %>user_guides/data/data_types/protein_families.html">Protein Families</a></div>
+                                    <div><a class="navigationLinkOut" href="<%- request.applicationOptions.docsServiceURL %>user_guides/data/data_types/specialty_genes.html">Specialty Genes</a></div>
+                                    <div><a class="navigationLinkOut" href="<%- request.applicationOptions.docsServiceURL %>user_guides/data/data_types/transcriptomics.html">Transcriptomics</a></div>
+                                </div>
+                                <div class="menuHeader">Download Data</div>
+                                <div class="menuItems">
+                                    <div><a class="navigationLinkOut" href="ftp://ftp.patricbrc.org/"
+                                            target="_blank" rel="noopener">FTP Server</a>
+                                    </div>
+                                </div>
                             </div>
-                            <div class="ShowWithAuth">
-                                <div><i class="fa icon-caret-down fa-1x noHoverIcon"
-                                        style="color:#333;cursor:normal;"></i>&nbsp;<a
-                                            class="navigationLink" id="YourWorkspaceLink">Workspaces</a></div>
-                                <div id="YourWorkspaces"></div>
-                                <div><a class="navigationLink" href="/workspace/public">Public Workspaces</a></div>
+                            <div style="vertical-align:top;width:200px;display: inline-block">
+                                <div class="menuHeader">Specialty Data Collections</div>
+                                <div class="menuItems">
+                                    <div><a class="navigationLinkOut" href="<%- request.applicationOptions.docsServiceURL %>user_guides/data/specialty_data_collections/patric_collaborations.html">PATRIC Collaborations</a></div>
+                                    <div><a class="navigationLinkOut" href="<%- request.applicationOptions.docsServiceURL %>user_guides/data/specialty_data_collections/patric_dbps.html">PATRIC DBPS</a></div>
+                                    <div><a class="navigationLinkOut" href="<%- request.applicationOptions.docsServiceURL %>user_guides/data/specialty_data_collections/niaid_clinical_proteomics.html">NIAID Clinical Proteomics</a></div>
+                                    <div><a class="navigationLinkOut" href="<%- request.applicationOptions.docsServiceURL %>user_guides/data/specialty_data_collections/niaid_genome_sequencing.html">NIAID Genome Sequencing</a></div>
+                                    <div><a class="navigationLinkOut" href="<%- request.applicationOptions.docsServiceURL %>user_guides/data/specialty_data_collections/niaid_structural_genomics.html">NIAID Structural Genomics</a></div>
+                                    <div><a class="navigationLinkOut" href="<%- request.applicationOptions.docsServiceURL %>user_guides/data/specialty_data_collections/niaid_systems_biology.html">NIAID Systems Biology</a></div>
+                                    <div><a class="navigationLinkOut" href="<%- request.applicationOptions.docsServiceURL %>user_guides/data/specialty_data_collections/niaid_functional_genomics.html">NIAID Functional Genomics</a></div>
+                                </div>
+
                             </div>
                         </div>
-                        <div style="vertical-align:top;display:inline-block" class="ShowWithAuth">
-                            <div>
-                                <a class="navigationLink" href="/job/">My Jobs</a>
+                    </div>
+                </div>
+
+                <div class="topMenuButton showOnLoad dijitHidden" data-dojo-type="dijit/form/DropDownButton">
+                    <span style="font-size: 1em; line-height: 1.5; margin-top: -10px;">WORKSPACES</span>
+
+                    <div data-dojo-type="p3/widget/TooltipDialog">
+                        <div>
+                            <div style="vertical-align: top;width:175px;display:inline-block">
+                                <div class="HideWithAuth">
+                                    Please <a class="loginLink">sign in</a> to view your workspaces.
+                                </div>
+                                <div class="ShowWithAuth">
+                                    <div><i class="fa icon-caret-down fa-1x noHoverIcon"
+                                            style="color:#333;cursor:normal;"></i>&nbsp;<a
+                                                class="navigationLink" id="YourWorkspaceLink">Workspaces</a></div>
+                                    <div id="YourWorkspaces"></div>
+                                    <div><a class="navigationLink" href="/workspace/public">Public Workspaces</a></div>
+                                </div>
                             </div>
-                            <div>
-                                <a class="navigationLink" href="/view/GenomeList/?eq(public,false)">My Genomes</a>
+                            <div style="vertical-align:top;display:inline-block" class="ShowWithAuth">
+                                <div>
+                                    <a class="navigationLink" href="/job/">My Jobs</a>
+                                </div>
+                                <div>
+                                    <a class="navigationLink" href="/view/GenomeList/?eq(public,false)">My Genomes</a>
+                                </div>
                             </div>
                         </div>
                     </div>
@@ -198,6 +200,8 @@
                 <input style="width:100%;font-size:1em;" class="showOnLoad dijitHidden"
                        data-dojo-type="p3/widget/GlobalSearch"/>
             </div>
+
+            <!-- <div class="navbar-flex-space" style="flex-grow: 0.85;"></div> -->
 
             <div class="HideWithAuth authLinks showOnLoad dijitHidden" style="padding: 3px 10px 0 0;">
                 <div class="RegistrationButton registrationLink" data-dojo-type="dijit/form/Button">Register</div>

--- a/views/home.ejs
+++ b/views/home.ejs
@@ -11,6 +11,22 @@
             <div class="bv-brc-info">
                 <h1>BACTERIAL AND VIRAL BIOINFORMATICS RESOURCE CENTER</h1>
                 <p>The Bacterial and Viral Bioinformatics Resource Center (BV-BRC) is an information system designed to support research on bacterial and viral infectious diseases via integration of vital pathogen information with rich data and analysis tools. BV-BRC combines two long-running centers: PATRIC, the bacterial system, and IRD/ViPR, the viral systems.</p>
+                <div class="browse" style="display: flex; align-items: center; justify-content: space-between;">
+                    <h3>BROWSE</h3>
+                    <a href="/view/Taxonomy/2157" class="navigationLink btn btn-blue">ARCHAEA</a>
+                    <a href="/view/Taxonomy/2" class="navigationLink btn btn-blue">BACTERIA</a>
+                    <a href="/view/Taxonomy/10239" class="navigationLink btn btn-blue">PHAGES</a>
+                    <a href="/view/Taxonomy/10239" class="navigationLink btn btn-blue">VIRUSES</a>
+                    <a href="/view/Host/?eq(taxon_lineage_ids,2759)#view_tab=genomes" class="navigationLink btn btn-blue" style="width: 150px;">EUKARYOTIC HOSTS</a>
+                </div>
+                <div class="search" style="display: flex; align-items: center; justify-content: space-between;">
+                    <h3>SEARCH</h3>
+                    <div class="global-search" style="flex-grow: 5;">
+                        <div style="padding: 6px 0px 2px 2px; flex-grow: 1">
+                            <input style="width:100%;font-size:1em;" class="showOnLoad dijitHidden" data-dojo-type="p3/widget/GlobalSearch" />
+                        </div>
+                    </div>
+                </div>
             </div>
 
             <div class="announcements">
@@ -69,7 +85,10 @@
             </div>
 
             <div class="twitter-feed">
-                <a class="twitter-timeline" data-lang="en" data-height="310" data-dnt="true" data-theme="light" href="https://twitter.com/BVBRC_DB?ref_src=twsrc%5Etfw">Tweets by BVBRC_DB</a>
+                <!-- <a class="twitter-timeline" data-lang="en" data-height="470" data-dnt="true" data-theme="light" href="https://twitter.com/BVBRC_DB?ref_src=twsrc%5Etfw">Tweets by BVBRC_DB</a>
+                <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script> -->
+
+                <a class="twitter-timeline" data-lang="en" data-height="410" data-dnt="true" data-theme="light" href="https://twitter.com/BVBRC_DB/lists/bvbrc?ref_src=twsrc%5Etfw">A Twitter List by BVBRC_DB</a>
                 <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
             </div>
         </div>
@@ -81,5 +100,8 @@
 <style>
     body.patric {
         min-width: 830px;
+    }
+    #p3header-search {
+        display: none;
     }
 </style>


### PR DESCRIPTION
This PR adds the search bar to the main BV-BRC section. It also adds the browse buttons section.

This PR also fixes some layout issues at tablet and smaller resolutions. It’s not perfect but works for what’s here at the moment. I originally wanted to have a nice mobile view but cannot without really thinking through how to modify the navigation menu at smaller resolutions because we have too much content in the menu bar. Some aspects would need to be hidden. The navigation menu needs further discussion. 

On resolutions 990px and smaller the layout consists of a now, non-broken two column grid and remains in this format.

**desktop**
![Screenshot_2020-09-09 Bacterial and Viral Bioinformatics Resource Center BV-BRC](https://user-images.githubusercontent.com/22353987/92611546-88043680-f27e-11ea-8029-c056ee8ff271.png)

**tablet or smaller**
![Screenshot_2020-09-09 Bacterial and Viral Bioinformatics Resource Center BV-BRC(1)](https://user-images.githubusercontent.com/22353987/92611578-8d618100-f27e-11ea-84a6-88ffd21b2d10.png)

