### PR TITLE
Add/Remove Genome Solr elements from website

### DIFF
--- a/public/js/p3/widget/ColumnsGenome.js
+++ b/public/js/p3/widget/ColumnsGenome.js
@@ -23,6 +23,11 @@ define(['./formatter'], function (formatter) {
       label: 'Genome ID',
       field: 'genome_id'
     },
+    other_names: {
+      label: 'Other Names',
+      field: 'other_names',
+      hidden: true
+    },
     owner: {
       label: 'Owner',
       field: 'owner',
@@ -61,26 +66,32 @@ define(['./formatter'], function (formatter) {
       field: 'plasmids',
       hidden: true
     },
+    segments: {
+      label: 'Segments',
+      field: 'Segments',
+      hidden: true
+    },
     contigs: {
       label: 'Contigs',
       field: 'contigs'
-    },
-    patric_cds: {
-      label: 'PATRIC CDS',
-      field: 'patric_cds'
-    },
-    refseq_cds: {
-      label: 'RefSeq CDS',
-      field: 'refseq_cds',
-      hidden: true
     },
     isolation_country: {
       label: 'Isolation Country',
       field: 'isolation_country'
     },
+    season: {
+      label: 'Season',
+      field: 'season',
+      hidden: true
+    },
     host_name: {
       label: 'Host Name',
       field: 'host_name'
+    },
+    host_common_name: {
+      label: 'Host Common Name',
+      field: 'host_common_name',
+      hidden: true
     },
     disease: {
       label: 'Disease',
@@ -153,6 +164,11 @@ define(['./formatter'], function (formatter) {
       field: 'publication',
       hidden: true
     },
+    authors: {
+      label: 'Authors',
+      field: 'authors',
+      hidden: true
+    },
     bioproject_accession: {
       label: 'BioProject Accession',
       field: 'bioproject_accession',
@@ -171,11 +187,6 @@ define(['./formatter'], function (formatter) {
     genbank_accessions: {
       label: 'GenBank Accessions',
       field: 'genbank_accessions',
-      hidden: true
-    },
-    refseq_accessions: {
-      label: 'RefSeq Accessions',
-      field: 'refseq_accessions',
       hidden: true
     },
     sequencing_platform: {
@@ -198,11 +209,6 @@ define(['./formatter'], function (formatter) {
       field: 'gc_content',
       hidden: true
     },
-    isolation_site: {
-      label: 'Isolation Site',
-      field: 'isolation_site',
-      hidden: true
-    },
     isolation_source: {
       label: 'Isolation Source',
       field: 'isolation_source',
@@ -217,26 +223,6 @@ define(['./formatter'], function (formatter) {
     geographic_location: {
       label: 'Geographic Location',
       field: 'geographic_location',
-      hidden: true
-    },
-    latitude: {
-      label: 'Latitude',
-      field: 'latitude',
-      hidden: true
-    },
-    longitude: {
-      label: 'Longitude',
-      field: 'longitude',
-      hidden: true
-    },
-    altitude: {
-      label: 'Altitude',
-      field: 'altitude',
-      hidden: true
-    },
-    depth: {
-      label: 'Depth',
-      field: 'depth',
       hidden: true
     },
     other_environmental: {
@@ -260,32 +246,10 @@ define(['./formatter'], function (formatter) {
       field: 'host_health',
       hidden: true
     },
-    body_sample_site: {
-      label: 'Body Sample Site',
-      field: 'body_sample_site',
-      hidden: true
-    },
-    body_sample_subsite: {
-      label: 'Body Sample Subsite',
-      field: 'body_sample_subsite',
-      hidden: true
-    },
     other_clinical: {
       label: 'Other Clinical',
       field: 'other_clinical',
       hidden: true
-    },
-    antimicrobial_resistance: {
-      label: 'Antimicrobial Resistance',
-      field: 'antimicrobial_resistance',
-      hidden: true,
-      sortable: false
-    },
-    antimicrobial_resistance_evidence: {
-      label: 'Antimicrobial Resistance Evidence',
-      field: 'antimicrobial_resistance_evidence',
-      hidden: true,
-      sortable: false
     },
     gram_stain: {
       label: 'Gram Stain',
@@ -359,6 +323,11 @@ define(['./formatter'], function (formatter) {
     genome_quality: {
       label: 'Genome Quality',
       field: 'genome_quality',
+      hidden: true
+    },
+    mat_peptide: {
+      label: 'Mat Peptide',
+      field: 'mat_peptide',
       hidden: true
     },
     genome_quality_flags: {

--- a/public/js/p3/widget/DataItemFormatter.js
+++ b/public/js/p3/widget/DataItemFormatter.js
@@ -1521,6 +1521,11 @@ define([
           text: 'genome_name',
           mini: true
         }, {
+          name: 'Other Names',
+          text: 'other_names',
+          mini: true,
+          editable: true
+        }, {
           name: 'NCBI Taxon ID',
           text: 'taxon_id',
           link: 'http://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?id='
@@ -1586,14 +1591,6 @@ define([
           name: 'Type Strain',
           text: 'type_strain',
           editable: true
-        }, {
-          name: 'Antimicrobial Resistance',
-          text: 'antimicrobial_resistance',
-          link: function (obj) {
-            return lang.replace('<a href="/view/Genome/{obj.genome_id}#view_tab=amr">AMR Phenotypes</a>', { obj: obj });
-          },
-          editable: true,
-          isList: false // not displayed as list although returned as list
         }, {
           name: 'Reference Genome',
           text: 'reference_genome'
@@ -1683,18 +1680,9 @@ define([
           text: 'genbank_accessions',
           link: 'http://www.ncbi.nlm.nih.gov/nuccore/',
           editable: true
-        }, {
-          name: 'RefSeq Accessions',
-          text: 'refseq_accessions',
-          link: 'http://www.ncbi.nlm.nih.gov/nuccore/',
-          editable: true
         }],
 
         'Sequence Info': [{
-          name: 'Sequencing Status',
-          text: 'sequencing_status',
-          editable: true
-        }, {
           name: 'Sequencing Platform',
           text: 'sequencing_platform',
           editable: true
@@ -1724,22 +1712,9 @@ define([
         }, {
           name: 'GC Content',
           text: 'gc_content'
-        }, {
-          name: 'PATRIC CDS',
-          text: 'patric_cds',
-          link: function (obj) {
-            return lang.replace('<a href="/view/Genome/{obj.genome_id}#view_tab=features&filter=and(eq(feature_type,CDS),eq(annotation,PATRIC))">{obj.patric_cds}</a>', { obj: obj });
-          }
-        }, {
-          name: 'RefSeq CDS',
-          text: 'refseq_cds'
         }],
 
         'Isolate Info': [{
-          name: 'Isolation Site',
-          text: 'isolation_site',
-          editable: true
-        }, {
           name: 'Isolation Source',
           text: 'isolation_source',
           editable: true,
@@ -1759,28 +1734,16 @@ define([
           editable: true,
           type: 'date'
         }, {
+          name: 'Season',
+          text: 'season',
+          editable: true
+        }, {
           name: 'Isolation Country',
           text: 'isolation_country',
           editable: true
         }, {
           name: 'Geographic Location',
           text: 'geographic_location',
-          editable: true
-        }, {
-          name: 'Latitude',
-          text: 'latitude',
-          editable: true
-        }, {
-          name: 'Longitude',
-          text: 'longitude',
-          editable: true
-        }, {
-          name: 'Altitude',
-          text: 'altitude',
-          editable: true
-        }, {
-          name: 'Depth',
-          text: 'depth',
           editable: true
         }, {
           name: 'Other Environmental',
@@ -1794,6 +1757,10 @@ define([
           text: 'host_name',
           editable: true
         }, {
+          name: 'Host Common Name',
+          text: 'host_common_name',
+          editable: true
+        }, {
           name: 'Host Gender',
           text: 'host_gender',
           editable: true
@@ -1804,14 +1771,6 @@ define([
         }, {
           name: 'Host Health',
           text: 'host_health',
-          editable: true
-        }, {
-          name: 'Body Sample Site',
-          text: 'body_sample_site',
-          editable: true
-        }, {
-          name: 'Body Sample Subsite',
-          text: 'body_sample_subsite',
           editable: true
         }, {
           name: 'Other Clinical',


### PR DESCRIPTION
This pull request adds and removes genome solr fields from the genome view page, genomes tab sidebar, and + columns menu.

**Added to Genome View Page / Genomes Tab Sidebar**
* other_names
* season
* host_common_name

**Added to + columns menu**
* other_names
* authors
* segments
* mat_peptide
* season
* host_common_name


**Removed from Genome View Page / Genomes Tab Sidebar**
* refseq_accessions
* sequencing_status
* patric_cds
* refseq_cds
* isolation_site
* latitude
* longitude
* altitude
* depth
* body_sample_site
* body_sample_subsite
* antimicrobial_resistance

**Removed from + columns menu**
* refseq_accessions
* sequencing_status
* patric_cds
* refseq_cds
* isolation_site
* latitude
* longitude
* altitude
* depth
* body_sample_site
* body_sample_subsite
* antimicrobial_resistance
* antimicrobial_resistance_evidence