### PR TITLE
Features/jbrowse install

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -29,9 +29,6 @@
 [submodule "public/js/msa"]
 	path = public/js/msa
 	url = https://github.com/aswarren/msa.git
-[submodule "public/js/jbrowse"]
-	path = public/js/jbrowse.repo
-	url = https://github.com/GMOD/jbrowse.git
 [submodule "public/js/FileSaver"]
 	path = public/js/FileSaver
 	url = https://github.com/dkasenberg/FileSaver.js.git

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "flag-icon-css": "^2.8.0",
     "formidable": "^1.1.1",
     "http-proxy": "^1.15.2",
-    "jbrowse": "github:GMOD/jbrowse#faf2258d98a9611a219fd138759fbf15101d0905",
+    "jbrowse": "github:GMOD/jbrowse#759433708fe59e2c0a09e781cf93dc7ec4670461",
     "jquery": "^3.3.1",
     "morgan": "^1.9.1",
     "multibigwig": "github:BV-BRC/multibigwig#master",

--- a/package.json
+++ b/package.json
@@ -9,8 +9,7 @@
     "eslint:fix": "./node_modules/eslint/bin/eslint.js --fix public/js/p3",
     "eslint:test": "./node_modules/eslint/bin/eslint.js public/js/p3",
     "test:intern": "./node_modules/.bin/intern",
-    "preinstall": "rm -rf node_modules/multibigwig",
-    "postinstall": "mv -f node_modules/multibigwig public/js/jbrowse.repo/plugins/"
+    "postinstall": "./post_install.sh"
   },
   "dependencies": {
     "body-parser": "^1.19.0",
@@ -31,10 +30,10 @@
     "flag-icon-css": "^2.8.0",
     "formidable": "^1.1.1",
     "http-proxy": "^1.15.2",
-    "jbrowse": "GMOD/jbrowse#faf2258d98a9611a219fd138759fbf15101d0905",
+    "jbrowse": "github:GMOD/jbrowse#faf2258d98a9611a219fd138759fbf15101d0905",
     "jquery": "^3.3.1",
     "morgan": "^1.9.1",
-    "multibigwig": "BV-BRC/multibigwig#master",
+    "multibigwig": "github:BV-BRC/multibigwig#master",
     "nconf": "^0.7.1",
     "newrelic": "^4.1.4",
     "nodemailer": "^1.3.0",

--- a/package.json
+++ b/package.json
@@ -8,9 +8,11 @@
     "move-src": "cp gulpified/app/app.js src/app/ && cp gulpified/app/p3app.js src/app/ && cp gulpified/widget/LoginForm.js src/widget",
     "eslint:fix": "./node_modules/eslint/bin/eslint.js --fix public/js/p3",
     "eslint:test": "./node_modules/eslint/bin/eslint.js public/js/p3",
-    "test:intern": "./node_modules/.bin/intern"
+    "test:intern": "./node_modules/.bin/intern",
+    "postinstall": "mv node_modules/@gmod/jbrowse/* public/js/jbrowse.repo"
   },
   "dependencies": {
+    "@gmod/jbrowse": "1.16.11",
     "body-parser": "^1.19.0",
     "clipboard-js": "^0.3.5",
     "cookie-parser": "~1.3.3",
@@ -31,6 +33,7 @@
     "http-proxy": "^1.15.2",
     "jquery": "^3.3.1",
     "morgan": "^1.9.1",
+    "multibigwig": "BV-BRC/multibigwig#master",
     "nconf": "^0.7.1",
     "newrelic": "^4.1.4",
     "nodemailer": "^1.3.0",

--- a/package.json
+++ b/package.json
@@ -9,10 +9,10 @@
     "eslint:fix": "./node_modules/eslint/bin/eslint.js --fix public/js/p3",
     "eslint:test": "./node_modules/eslint/bin/eslint.js public/js/p3",
     "test:intern": "./node_modules/.bin/intern",
-    "postinstall": "mv node_modules/@gmod/jbrowse/* public/js/jbrowse.repo"
+    "preinstall": "rm -rf node_modules/multibigwig",
+    "postinstall": "mv -f node_modules/multibigwig public/js/jbrowse.repo/plugins/"
   },
   "dependencies": {
-    "@gmod/jbrowse": "1.16.11",
     "body-parser": "^1.19.0",
     "clipboard-js": "^0.3.5",
     "cookie-parser": "~1.3.3",
@@ -31,6 +31,7 @@
     "flag-icon-css": "^2.8.0",
     "formidable": "^1.1.1",
     "http-proxy": "^1.15.2",
+    "jbrowse": "GMOD/jbrowse#faf2258d98a9611a219fd138759fbf15101d0905",
     "jquery": "^3.3.1",
     "morgan": "^1.9.1",
     "multibigwig": "BV-BRC/multibigwig#master",

--- a/post_install.sh
+++ b/post_install.sh
@@ -1,5 +1,6 @@
 #!/bin/sh     
 cd public/js/
+rm -rf ./jbrowse.repo
 ln -sf ../../node_modules/jbrowse ./jbrowse.repo
 cd ./jbrowse.repo/plugins/
 ln -sf ../../multibigwig ./

--- a/post_install.sh
+++ b/post_install.sh
@@ -1,0 +1,6 @@
+#!/bin/sh     
+cd public/js/
+ln -sf ../../node_modules/jbrowse ./jbrowse.repo
+cd ./jbrowse.repo/plugins/
+ln -sf ../../multibigwig ./
+

--- a/public/js/jbrowse.conf
+++ b/public/js/jbrowse.conf
@@ -67,7 +67,7 @@ include += {dataRoot}/tracks
 ## uncomment and edit the example below to enable one or more
 ## JBrowse plugins
 # [ plugins.MyPlugin ]
-# location = plugins/MyPlugin
+location = plugins/multibigwig
 # [ plugins.AnotherPlugin ]
 # location = ../plugin/dir/someplace/else
 

--- a/public/js/jbrowse.repo
+++ b/public/js/jbrowse.repo
@@ -1,0 +1,1 @@
+../../node_modules/jbrowse


### PR DESCRIPTION
Hi @hyoo the following changes to an npm install of jbrowse.
I wasn't able to use the latest JBrowse 1.16.11 commits, so will leave that for a future exercise.
This also installs the Vipr requested multibigwig plugin for jbrowse.
All that should be necessary is to do an "npm install" and the replacements and installs will go into effect.
*Warning* make sure there are no local, un-committed modifications to the jbrowse submodule that you want to keep.