### PR TITLE
Features/jmol

### DIFF
--- a/public/js/p3/widget/EpitopeGrid.js
+++ b/public/js/p3/widget/EpitopeGrid.js
@@ -26,7 +26,7 @@ define([
     showFooter: false,
     fullSelectAll: false,
     columns: {
-      checkbox: selector({ selectorType: 'checkbox', unhidable: true, width: 400 }),
+      checkbox: selector({ selectorType: 'checkbox', unhidable: true, width: 25 }),
       id: { label: 'IEDB ID', field: 'id' },
       name: { label: 'SEQ', field: 'name', className: 'proteinStructure-hl-cell' }
     },

--- a/public/js/p3/widget/proteinStructure/SARS2FeatureHighlights.js
+++ b/public/js/p3/widget/proteinStructure/SARS2FeatureHighlights.js
@@ -28,7 +28,7 @@ define([
     positions: new Map(),
     FeatureList: declare([Grid], {
       columns: {
-        checkbox: selector({ unhidable: true, selectorType: 'checkbox', width: 400 }),
+        checkbox: selector({ unhidable: true, selectorType: 'checkbox', width: 25 }),
         name: { label: 'Name', className: 'proteinStructure-hl-cell' }
       },
       selectionMode: 'multiple',

--- a/public/js/p3/widget/viewer/ProteinStructure.js
+++ b/public/js/p3/widget/viewer/ProteinStructure.js
@@ -174,6 +174,7 @@ function (
       this.displayControl.set('accessionId', viewState.get('accession').id);
       this.epitopeHighlight.set('positions', viewState.get('highlights').get('epitopes'));
       this.featureHighlights.set('accessionId', viewState.get('accession').id);
+      this.epitopeHighlight.set('accessionId', viewState.get('accession').id);
       this.jsmol.set('viewState', viewState);
       this.updateAccessionInfo(viewState.get('accession'));
     },


### PR DESCRIPTION
Fix checkbox width
Add back setting accessionId on epitopeHighlight which triggers loading of structure specific epitope data.