### PR TITLE
Updates for SARS-COV-2 Variants and Lineages of Concern

### DIFF
--- a/public/js/p3/widget/GenomeBrowser.js
+++ b/public/js/p3/widget/GenomeBrowser.js
@@ -1006,7 +1006,7 @@ define([
         highResoutionMode: 'auto',
         // alwaysOnTracks: [,"PATRICGenes"].join(","),
         initialHighlight: (state && state.hashParams) ? state.hashParams.highlight : undefined,
-        plugins: ['HideTrackLabels'],
+        plugins: ['HideTrackLabels', 'MultiBigWig'],
         show_nav: (state && state.hashParams && (typeof state.hashParams.show_nav != 'undefined')) ? state.hashParams.show_nav : true,
         show_tracklist: (state && state.hashParams && (typeof state.hashParams.show_tracklist != 'undefined')) ? state.hashParams.show_tracklist : true,
         show_overview: (state && state.hashParams && (typeof state.hashParams.show_overview != 'undefined')) ? state.hashParams.show_overview : true,

--- a/public/js/p3/widget/viewer/VariantLineage.js
+++ b/public/js/p3/widget/viewer/VariantLineage.js
@@ -78,7 +78,7 @@ define([
             hashParams: {
               view_tab: 'jbrowse',
               loc: 'NC_045512%3A1..29903',
-              tracks: 'RefSeqGFF%2CActivesite%2CRegionofinterest%2CDomains%2CMutagenesisSite%2CVOCMarkers%2CHumanBCellEpitopes'
+              tracks: 'RefSeqGFF%2CActivesite%2CRegionofinterest%2CDomains%2CMutagenesisSite%2CVOCMarkers%2CHumanBCellEpitopes%2CClasses1to4AbEscape'
             }
           });
           activeTab.set('state', activeQueryState);


### PR DESCRIPTION
Just two small changes -- one adds MultiBigWig to the plugins list in Genome Browser and the other adds a default view to the displayed page.   These changes go with a PR I just did to PATRIC/p3_api bv-brc branch and the default view will break unless the p3_api PR is already done.  Thanks.